### PR TITLE
パッケージバージョンの更新

### DIFF
--- a/DotnetLab202405/DotnetLab202405.csproj
+++ b/DotnetLab202405/DotnetLab202405.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.2" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.8.0" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
パッケージバージョンの更新

DotnetLab202405.csprojファイルにおいて、以下のパッケージのバージョンが更新されました。
- `Microsoft.AspNetCore.Components.WebAssembly`: 8.0.6 → 8.0.10
- `Microsoft.AspNetCore.Components.WebAssembly.DevServer`: 8.0.6 → 8.0.10
- `Microsoft.FluentUI.AspNetCore.Components`: 4.8.0 → 4.10.2
- `Microsoft.FluentUI.AspNetCore.Components.Icons`: 4.8.0 → 4.10.2