### PR TITLE
ターゲットフレームワークとパッケージの更新

### DIFF
--- a/DotnetLab202405/DotnetLab202405.csproj
+++ b/DotnetLab202405/DotnetLab202405.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0-rc.2.24474.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.3" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.3" />


### PR DESCRIPTION
ターゲットフレームワークとパッケージの更新

プロジェクトのターゲットフレームワークが `net8.0` から `net9.0` に変更されました。
`Microsoft.AspNetCore.Components.WebAssembly` パッケージのバージョンが `8.0.10` から `9.0.0-rc.2.24474.3` に更新されました。
`Microsoft.AspNetCore.Components.WebAssembly.DevServer` パッケージのバージョンが `8.0.10` から `9.0.0-rc.2.24474.3` に更新されました。